### PR TITLE
Update docker-compose.yml

### DIFF
--- a/Docker/docker-compose.yml
+++ b/Docker/docker-compose.yml
@@ -21,9 +21,8 @@ services:
       - --config.file=/etc/prometheus/prometheus.yml
       - --storage.tsdb.path=/prometheus
       - --storage.tsdb.retention.time=45d
-      - --internal.console.libraries=/usr/share/prometheus/console_libraries
-      - --internal.console.templates=/usr/share/prometheus/consoles
-      - --internal.enable-admin-api
+      - --web.console.libraries=/usr/share/prometheus/console_libraries
+      - --web.console.templates=/usr/share/prometheus/consoles
     networks:
       - internal
     ports:


### PR DESCRIPTION
fix error run docker-compose prometheus-home 
 Error parsing command line arguments: unknown long flag '--internal.console.libraries'
prometheus: error: unknown long flag '--internal.console.libraries'

add lines 
- --web.console.libraries=/usr/share/prometheus/console_libraries
- --web.console.templates=/usr/share/prometheus/consoles

and delete 
- --internal.console.libraries=/usr/share/prometheus/console_libraries
- --internal.console.templates=/usr/share/prometheus/consoles  
- --internal.enable-admin-api